### PR TITLE
Fix for #20 when 'uncategorized' does not exist

### DIFF
--- a/config/config_interface.py
+++ b/config/config_interface.py
@@ -241,8 +241,10 @@ def load_footprint_paths(user_config_path: str, footprint_path: str) -> dict:
 				footprint_libraries_paths['uncategorized'].append(folder)
 			except:
 				footprint_libraries_paths['uncategorized'] = [folder]
-	footprint_libraries_paths['uncategorized'] = sorted(
-		footprint_libraries_paths['uncategorized'])
+	
+	if 'uncategorized' in footprint_libraries_paths:
+		footprint_libraries_paths['uncategorized'] = sorted(
+			footprint_libraries_paths['uncategorized'])
 
 	return footprint_libraries_paths
 


### PR DESCRIPTION
In my case, the `'uncategorized'` category did not exist in `footprint_libraries_paths`.  Trying to sort it was causing this error:

```
Traceback (most recent call last):
  File "/Users/chris/Projects/Ki-nTree/kintree_gui.py", line 6, in <module>
    import config.settings as settings
  File "/Users/chris/Projects/Ki-nTree/config/settings.py", line 157, in <module>
    footprint_libraries_paths = config_interface.load_footprint_paths(
  File "/Users/chris/Projects/Ki-nTree/config/config_interface.py", line 249, in load_footprint_paths
    footprint_libraries_paths['uncategorized'])
KeyError: 'uncategorized'
```

This adds a check to make sure the category exists before trying to sort it.