### PR TITLE
0.3.8

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -245,7 +245,12 @@ def load_inventree_settings():
 	PASSWORD = inventree_settings.get('PASSWORD', None)
 	# Part URL
 	if SERVER_ADDRESS:
-		PART_URL_ROOT = SERVER_ADDRESS + 'part/'
+		# If missing, append slash to root URL
+		root_url = SERVER_ADDRESS
+		if not SERVER_ADDRESS.endswith('/'):
+			root_url = root_url + '/'
+		# Set part URL
+		PART_URL_ROOT = root_url + 'part/'
 
 # Default revision
 INVENTREE_DEFAULT_REV = inventree_settings.get('INVENTREE_DEFAULT_REV', 'A')

--- a/config/version.yaml
+++ b/config/version.yaml
@@ -1,4 +1,4 @@
 MAJOR_REVISION: 0
 MINOR_REVISION: 3
 # Digit means stable version
-RELEASE_STATE: 7
+RELEASE_STATE: 8

--- a/database/inventree_api.py
+++ b/database/inventree_api.py
@@ -135,7 +135,7 @@ def is_new_part(category_id: int, part_info: dict) -> int:
 			parameter_value = parameter.data
 			part_parameters[parameter_name] = parameter_value
 
-		if new_part_parameters:
+		if new_part_parameters and part_parameters:
 			# Compare database part with new part
 			compare = part_tools.compare(new_part_parameters=new_part_parameters,
 										 db_part_parameters=part_parameters,

--- a/kintree_gui.py
+++ b/kintree_gui.py
@@ -1126,5 +1126,8 @@ def main():
 if __name__ == '__main__':
 	# Disable Digi-Key API logger
 	digikey_api.disable_digikey_api_logger()
+	# Fix for Windows EXE
+	import multiprocessing
+	multiprocessing.freeze_support()
 	# Run main window
 	main()


### PR DESCRIPTION
* Fixed build issue which was omitting `settings` folder
* Fixed part URL when missing slash was missing from InvenTree base URL
* Ensure parameters comparison when they exist for both database and new part
* Fix for building and running EXE in Windows