### PR TITLE
Use local CA certs for Inventree on Linux

### DIFF
--- a/database/inventree_api.py
+++ b/database/inventree_api.py
@@ -4,6 +4,8 @@ from common import part_tools
 from common.tools import cprint, download_image
 from config import config_interface
 
+# Required to use local CA certificates on Linux
+# For more details, refer to https://github.com/sparkmicro/Ki-nTree/pull/45
 import platform
 if platform.system() == 'Linux':
     import os

--- a/database/inventree_api.py
+++ b/database/inventree_api.py
@@ -3,6 +3,14 @@ import validators
 from common import part_tools
 from common.tools import cprint, download_image
 from config import config_interface
+
+import platform
+if platform.system() == 'Linux':
+    import os
+    cert_path = '/etc/ssl/certs/ca-certificates.crt'
+    if os.path.isfile(cert_path):
+        os.environ['REQUESTS_CA_BUNDLE'] = cert_path
+
 # InvenTree
 from inventree.api import InvenTreeAPI
 from inventree.base import Parameter, ParameterTemplate


### PR DESCRIPTION
This allows you to use your own, self-signed certificates on Linux.
If the '/etc/ssl/certs/ca-certificates.crt' file doesn't exist, the
program won't try to use local certificates.

None of this applies on non-Linux platforms.

Tested on my instance, works properly.

Fixes #36.