### PR TITLE
0.4.3 Bug fixes

### DIFF
--- a/kintree/config/settings.py
+++ b/kintree/config/settings.py
@@ -10,7 +10,7 @@ from .import config_interface
 version_info = {
     'MAJOR_REVISION': 0,
     'MINOR_REVISION': 4,
-    'RELEASE_STATUS': 2,  # Digit means stable version
+    'RELEASE_STATUS': 3,  # Digit means stable version
 }
 try:
     version = '.'.join([str(v) for v in version_info.values()])

--- a/kintree/database/inventree_api.py
+++ b/kintree/database/inventree_api.py
@@ -388,11 +388,11 @@ def is_new_supplier_part(supplier_name: str, supplier_sku: str) -> bool:
 def create_manufacturer_part(part_id: int, manufacturer_name: str, manufacturer_mpn: str, description: str, datasheet: str) -> bool:
     ''' Create InvenTree manufacturer part
 
-            part_id: Part the manufacturer data is linked to
-            manufacturer: Company that manufactures the SupplierPart (leave blank if it is the sample as the Supplier!)
-            MPN: Manufacture part number
-            datasheet: Datasheet link
-            description: Descriptive notes field
+        part_id: Part the manufacturer data is linked to
+        manufacturer: Company that manufactures the SupplierPart (leave blank if it is the sample as the Supplier!)
+        MPN: Manufacture part number
+        datasheet: Datasheet link
+        description: Descriptive notes field
     '''
     global inventree_api
 
@@ -424,25 +424,24 @@ def create_manufacturer_part(part_id: int, manufacturer_name: str, manufacturer_
 def create_supplier_part(part_id: int, manufacturer_name: str, manufacturer_mpn: str, supplier_name: str, supplier_sku: str, description: str, link: str) -> bool:
     ''' Create InvenTree supplier part
 
-            part_id: Part the supplier data is linked to
-            manufacturer_name: Manufacturer the supplier data is linked to
-            manufacturer_mpn: MPN the supplier data is linked to
-            supplier: Company that supplies this SupplierPart object
-            SKU: Stock keeping unit (supplier part number)
-            manufacturer: Company that manufactures the SupplierPart (leave blank if it is the sample as the Supplier!)
-            MPN: Manufacture part number
-            link: Link to part detail page on supplier's website
-            description: Descriptive notes field
+        part_id: Part the supplier data is linked to
+        manufacturer_name: Manufacturer the supplier data is linked to
+        manufacturer_mpn: MPN the supplier data is linked to
+        supplier: Company that supplies this SupplierPart object
+        SKU: Stock keeping unit (supplier part number)
+        manufacturer: Company that manufactures the SupplierPart (leave blank if it is the sample as the Supplier!)
+        MPN: Manufacture part number
+        link: Link to part detail page on supplier's website
+        description: Descriptive notes field
     '''
     global inventree_api
 
     # Get Supplier ID
     supplier_id = get_company_id(supplier_name)
 
-    # Get Manufacturer ID
-    manufacturer_id = get_company_id(manufacturer_name)
-    if not manufacturer_id:
-        # Unset MPN
+    if not manufacturer_name or not manufacturer_mpn:
+        # Unset manufacturer data
+        manufacturer_name = None
         manufacturer_mpn = None
 
     if supplier_id:
@@ -452,7 +451,7 @@ def create_supplier_part(part_id: int, manufacturer_name: str, manufacturer_mpn:
 
         supplier_part = SupplierPart.create(inventree_api, {
             'part': part_id,
-            'manufacturer': manufacturer_id,
+            'manufacturer': manufacturer_name,
             'MPN': manufacturer_mpn,
             'supplier': supplier_id,
             'SKU': supplier_sku,

--- a/kintree/kintree_gui.py
+++ b/kintree/kintree_gui.py
@@ -537,7 +537,8 @@ def user_defined_symbol_template_footprint(categories: list,
         for cat in items.keys():
             if cat != category and cat != 'uncategorized':
                 for key in items[cat].keys():
-                    more_choices.append(key)
+                    if key not in choices and key not in more_choices:
+                        more_choices.append(key)
 
         # Process uncategorized entries
         try:
@@ -1032,13 +1033,13 @@ def main():
                     else:
                         if not categories[0]:
                             pseudo_categories = [symbol, None]
-                            part_data = inventree_interface.translate_supplier_to_inventree(supplier=values['supplier'],
-                                                                                            part_info=part_info,
-                                                                                            categories=pseudo_categories)
+                            part_data = inventree_interface.translate_form_to_inventree(part_info=part_info,
+                                                                                        categories=pseudo_categories,
+                                                                                        is_custom=CREATE_CUSTOM)
                         else:
-                            part_data = inventree_interface.translate_supplier_to_inventree(supplier=values['supplier'],
-                                                                                            part_info=part_info,
-                                                                                            categories=categories)
+                            part_data = inventree_interface.translate_form_to_inventree(part_info=part_info,
+                                                                                        categories=categories,
+                                                                                        is_custom=CREATE_CUSTOM)
                             part_data['parameters']['Symbol'] = symbol
                             part_data['parameters']['Footprint'] = footprint
                         if not part_data:
@@ -1055,6 +1056,10 @@ def main():
                             part_data['IPN'] = part_data['name']
                     else:
                         part_data['IPN'] = values['part_number']
+
+                    # Replace spaces with hyphens
+                    part_data['IPN'] = part_data['IPN'].replace(' ', '-')
+
                     if part_data['datasheet']:
                         part_data['inventree_url'] = part_data['datasheet']
 

--- a/kintree/kintree_gui.py
+++ b/kintree/kintree_gui.py
@@ -110,6 +110,7 @@ def search_api_settings_window():
             }
             user_settings = {**user_settings, **new_settings}
             config_interface.dump_file(user_settings, settings.CONFIG_DIGIKEY_API)
+            digikey_api.setup_environment(force=True)
 
         if api_event == sg.WIN_CLOSED:
             search_api_window.close()

--- a/kintree/search/digikey_api.py
+++ b/kintree/search/digikey_api.py
@@ -29,7 +29,7 @@ if not os.path.exists(os.environ['DIGIKEY_STORAGE_PATH']):
 
 def disable_api_logger():
     # Digi-Key API logger
-    logging.getLogger('digikey.v3.api').setLevel(logging.WARNING)
+    logging.getLogger('digikey.v3.api').setLevel(logging.CRITICAL)
     # Disable DEBUG
     logging.disable(logging.DEBUG)
 
@@ -44,8 +44,8 @@ def check_environment() -> bool:
     return True
 
 
-def setup_environment() -> bool:
-    if not check_environment():
+def setup_environment(force=False) -> bool:
+    if not check_environment() or force:
         # SETUP the Digikey authentication see https://developer.digikey.com/documentation/organization#production
         digikey_api_settings = config_interface.load_file(settings.CONFIG_DIGIKEY_API)
         os.environ['DIGIKEY_CLIENT_ID'] = digikey_api_settings['DIGIKEY_CLIENT_ID']

--- a/poetry.lock
+++ b/poetry.lock
@@ -93,7 +93,7 @@ python-versions = ">=3.5"
 
 [[package]]
 name = "digikey-api"
-version = "0.4.0"
+version = "0.5.0"
 description = "Python client for Digikey API"
 category = "main"
 optional = false

--- a/poetry.lock
+++ b/poetry.lock
@@ -164,7 +164,7 @@ python-versions = ">=3.5"
 
 [[package]]
 name = "inventree"
-version = "0.2.4"
+version = "0.4.4"
 description = "Python interface for InvenTree inventory management system"
 category = "main"
 optional = false
@@ -349,7 +349,7 @@ python-versions = "*"
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.7,<3.10"
-content-hash = "b6dad2f9717971987d802c26c0a65d60095c30572ebbebd17b6da765bf376518"
+content-hash = "514627aac92c7b1061f5f5ff606eec7be3d7efa9157a95cf5883ed625ffc6730"
 
 [metadata.files]
 certauth = [
@@ -492,8 +492,8 @@ decorator = [
     {file = "decorator-5.0.6.tar.gz", hash = "sha256:f2e71efb39412bfd23d878e896a51b07744f2e2250b2e87d158e76828c5ae202"},
 ]
 digikey-api = [
-    {file = "digikey-api-0.4.0.tar.gz", hash = "sha256:b21c75f26cd34e6da99191b643edebb2a188bd9f91654065d42a5f70901d19de"},
-    {file = "digikey_api-0.4.0-py3-none-any.whl", hash = "sha256:591ef340faa50ba3147e2adf162ed03517efc0932b391b8f4903c85743ddb840"},
+    {file = "digikey-api-0.5.0.tar.gz", hash = "sha256:7b9b15c5880dfcfc7f8bbb2551234cb1af556bd98a71c143ce68cc4ce40d99c3"},
+    {file = "digikey_api-0.5.0-py3-none-any.whl", hash = "sha256:2f794103ac30849856cbb1d0ff5a87cf00481b62bd737f37f0f0f15d37b4c14c"},
 ]
 dill = [
     {file = "dill-0.3.4-py2.py3-none-any.whl", hash = "sha256:7e40e4a70304fd9ceab3535d36e58791d9c4a776b38ec7f7ec9afc8d3dca4d4f"},
@@ -518,8 +518,8 @@ inflection = [
     {file = "inflection-0.5.1.tar.gz", hash = "sha256:1a29730d366e996aaacffb2f1f1cb9593dc38e2ddd30c91250c6dde09ea9b417"},
 ]
 inventree = [
-    {file = "inventree-0.2.4-py2.py3-none-any.whl", hash = "sha256:5d714f7a52e5f2a29218c82ba8cb53ae2928dd23c4374c22d8b35e6e25a7bac7"},
-    {file = "inventree-0.2.4.tar.gz", hash = "sha256:8f5461f4aac4bc6f19b83d2ca96ed430e46cb42a699b058d47da51ec505dc957"},
+    {file = "inventree-0.4.4-py2.py3-none-any.whl", hash = "sha256:ec7bb0ba30c5993a070ba34834a84cfcc8e235bafa04671e790b69031b600003"},
+    {file = "inventree-0.4.4.tar.gz", hash = "sha256:721a1bb626dd8941728c923ae768d0dcfc7a2712a570d3adeac9b635826c07b2"},
 ]
 invoke = [
     {file = "invoke-1.6.0-py2-none-any.whl", hash = "sha256:e6c9917a1e3e73e7ea91fdf82d5f151ccfe85bf30cc65cdb892444c02dbb5f74"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ keywords = ["inventree", "kicad", "component", "part", "create"]
 python = ">=3.7,<3.10"
 digikey-api = ">=0.5.0,<1.0"
 fuzzywuzzy = ">=0.18.0,<1.0"
-inventree = ">=0.2.4,<1.0"
+inventree = ">=0.4.4,<1.0"
 multiprocess = ">=0.70.12.2,<0.71"
 PySimpleGUI = ">=4.28.0,<5.0"
 PyYAML = ">=5.3.1,<6.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ keywords = ["inventree", "kicad", "component", "part", "create"]
 
 [tool.poetry.dependencies]
 python = ">=3.7,<3.10"
-digikey-api = ">=0.4.0,<1.0"
+digikey-api = ">=0.5.0,<1.0"
 fuzzywuzzy = ">=0.18.0,<1.0"
 inventree = ">=0.2.4,<1.0"
 multiprocess = ">=0.70.12.2,<0.71"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-digikey-api>=0.4.0,<1.0
+digikey-api>=0.5.0,<1.0
 fuzzywuzzy>=0.18.0,<1.0
 inventree>=0.2.4,<1.0
 multiprocess>=0.70.12.2,<0.71

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 digikey-api>=0.5.0,<1.0
 fuzzywuzzy>=0.18.0,<1.0
-inventree>=0.2.4,<1.0
+inventree>=0.4.4,<1.0
 multiprocess>=0.70.12.2,<0.71
 PySimpleGUI>=4.28.0,<5.0
 PyYAML>=5.3.1,<6.0


### PR DESCRIPTION
* Updated link to manufacturer part using server hook implemented in: https://github.com/inventree/InvenTree/pull/1947
* Digi-Key API
  * Raised logger output level to "critical" (to hide ugly output)
  * Reloading environmental variables when settings are changed
* Fixed bugs related to KiCad only part creation
  * Was using obsolete methods to convert form data to inventree format
  * There were duplicates in footprint libraries selection
* Updated dependencies: `digikey-api>=0.5.0` and `inventree>=0.4.4`