### PR TITLE
Fix LCSC search

### DIFF
--- a/kintree/config/settings.py
+++ b/kintree/config/settings.py
@@ -125,7 +125,7 @@ except TypeError:
 SUPPORTED_SUPPLIERS_API = [
     'Digi-Key',
     'Mouser',
-    # 'LCSC',
+    'LCSC',
 ]
 
 # Digi-Key user configuration

--- a/kintree/search/lcsc_api.py
+++ b/kintree/search/lcsc_api.py
@@ -45,9 +45,9 @@ def fetch_part_info(part_number: str) -> dict:
     part_info = {}
 
     def search_timeout(timeout=10):
-        url = 'https://wwwapi.lcsc.com/v1/products/detail?product_code=' + part_number
+        url = 'https://wmsc.lcsc.com/wmsc/product/detail?productCode=' + part_number
         response = download(url, timeout=timeout)
-        return response
+        return response['result']
 
     # Query part number
     try:


### PR DESCRIPTION
Updating the URL used to search on LCSC and re-enabling it. This is an actual fix for #106.