### PR TITLE
0.6.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ Below is a summary table of the different configuration files, their function an
 | `parameters_filters.yaml` | Mapping between InvenTree parent categories and InvenTree parameters templates | :x: |
 | `search_api.yaml` | Generic controls for Supplier search APIs like cache validity and category matching ratio | :x: |
 | `supplier_parameters.yaml` | Mapping between InvenTree parameters templates and suppliers parameters/attributes, sorted by InvenTree parent categories (see [Part Parameters section](#part-parameters)) | :x: |
-| `<supplier>_config.yaml` | Mapping for supplier search results field names, to overwrite defaults (`<supplier>=['digikey', 'element14', 'lcsc', 'mouser']`) | :x: |
+| `<supplier>_config.yaml` | Mapping for supplier name and search results fields, to overwrite defaults (`<supplier>=['digikey', 'element14', 'lcsc', 'mouser']`) | :x: |
 | `<supplier>_api.yaml` | Required supplier API fields, custom to each supplier (`<supplier>=['digikey', 'element14', 'lcsc', 'mouser']`) | :heavy_check_mark: |
 | `digikey_categories.yaml` | Mapping between InvenTree categories and Digi-Key categories | :heavy_check_mark: |
 | `digikey_parameters.yaml` | Mapping between InvenTree parameters and Digi-Key parameters/attributes | :x: |
@@ -147,10 +147,11 @@ If you wish to automatically add subcategories while creating InvenTree parts, y
 Note that each time you enable the "Add" permission to an object, InvenTree automatically enables the "Change" permission to that object too.
 
 #### Settings
-1. With Ki-nTree GUI open, click on "Settings > Digi-Key" and fill in both Digi-Key API Client ID and Secret keys (optional: click on "Test" to [get an API token](#get-digi-key-api-token))
-2. Click on "Settings > Mouser" and fill in the Mouser part search API key
-3. Click on "Settings > KiCad", browse to the location where KiCad symbol, template and footprint libraries are stored on your computer then click "Save"
-4. If you intend to use InvenTree with this tool, click on "Settings > InvenTree" and fill in your InvenTree server address and credentials then click "Save" (optional: click on "Test" to get an API token)
+1. With Ki-nTree GUI open, click on "Settings > Supplier > Digi-Key" and fill in both Digi-Key API Client ID and Secret keys (optional: click on "Test" to [get an API token](#get-digi-key-api-token))
+2. Click on "Settings > Supplier > Mouser" and fill in the Mouser part search API key
+3. Click on "Settings > Supplier > Element14" and fill in the Element14 product search API key (key is shared with Farnell and Newark)
+4. Click on "Settings > KiCad", browse to the location where KiCad symbol, template and footprint libraries are stored on your computer then click "Save"
+5. If you intend to use InvenTree with this tool, click on "Settings > InvenTree" and fill in your InvenTree server address and credentials then click "Save" (optional: click on "Test" to get an API token)
 
 #### Get Digi-Key API token
 <details>
@@ -188,7 +189,7 @@ Refer to [this file](https://github.com/sparkmicro/Ki-nTree/blob/main/kintree/co
 
 #### Part Number Search
 
-Ki-nTree currently supports APIs for the following electronics suppliers: Digi-Key, Mouser and LCSC.
+Ki-nTree currently supports APIs for the following electronics suppliers: Digi-Key, Mouser, Element14 and LCSC.
 
 1. In the main window, enter the part number and select the supplier in drop-down list, then click "CREATE". It will start by fetching part data using the supplier's API
 2. In the case Digi-Key has been selected and the API token is not found or expired, a browser window will pop-up. To get a new token: [follow those steps](#get-digi-key-api-token)

--- a/kintree/config/settings.py
+++ b/kintree/config/settings.py
@@ -61,8 +61,8 @@ def load_user_config():
     CONFIG_USER_FILES = os.path.join(USER_SETTINGS['USER_FILES'], '')
 
     # Create user files folder if it does not exists
-    # if not os.path.exists(CONFIG_USER_FILES):
-    #     os.makedirs(CONFIG_USER_FILES)
+    if not os.path.exists(CONFIG_USER_FILES):
+        os.makedirs(CONFIG_USER_FILES)
     # Create user files
     return config_interface.load_user_config_files(path_to_root=CONFIG_ROOT,
                                                    path_to_user_files=CONFIG_USER_FILES,

--- a/kintree/kintree_gui.py
+++ b/kintree/kintree_gui.py
@@ -223,7 +223,7 @@ def element14_api_settings_window(supplier=''):
         [
             sg.Text(f'{supplier} Store', size=gui_global['big_label_size']),
             sg.Combo(sorted(element14_api.STORES[supplier]), default_value=default_store, key=f'{supplier.lower()}_store', enable_events=True),
-            sg.Text(f'URL: {element14_api.STORES[supplier][default_store]}', key='store_url'),
+            sg.Text(f'URL: {element14_api.STORES[supplier].get(default_store, "")}', key='store_url'),
         ],
         [
             sg.Button('Test', size=(15, 1)),
@@ -1246,6 +1246,9 @@ def main():
                             elif values['supplier'] == 'Mouser':
                                 error_message += '\n- Mouser API settings are correct ("Settings > Supplier > Mouser")' \
                                                  '\n- Part number is a valid number on Mouser\'s website'
+                            elif values['supplier'] in ['Farnell', 'Newark', 'Element14']:
+                                error_message += f'\n- {values["supplier"]} API key is correct and a store is selected ("Settings > Supplier > {values["supplier"]}")' \
+                                                 f'\n- Part number is a valid number on {values["supplier"]}\'s website'
                             elif values['supplier'] == 'LCSC':
                                 error_message += '\n- Mouser API settings are correct ("Settings > Supplier > LCSC")' \
                                                  '\n- Part number is a valid LCSC number (eg. starts with "C")'


### PR DESCRIPTION
- Fixes #112 (regression bug, introduced in `0.6.4`)
- Fixes #113 and a "New InvenTree Part" detection bug
- Fixes crash when no Farnell/Newark/Element14 store is selected and display a blank selection instead (ref: [this thread](https://forum.kicad.info/t/ki-ntree-fast-part-creation-in-kicad-and-inventree/24300/40))
- Fixed error message when Farnell/Newark/Element14 supplier search fails:

![image](https://user-images.githubusercontent.com/4020546/210863387-c3fd5772-21f6-467b-bbf6-87a27ee97717.png)

- Added overwrite of manufacturer name with matching database entry (partial ratio) per feedback from Kedarius in [this thread](https://forum.kicad.info/t/ki-ntree-fast-part-creation-in-kicad-and-inventree/24300/40)
- Updates to README