### PR TITLE
add support for token and proxy access to inventree

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ Note that each time you enable the "Add" permission to an object, InvenTree auto
 2. Click on "Settings > Supplier > Mouser" and fill in the Mouser part search API key
 3. Click on "Settings > Supplier > Element14" and fill in the Element14 product search API key (key is shared with Farnell and Newark)
 4. Click on "Settings > KiCad", browse to the location where KiCad symbol, template and footprint libraries are stored on your computer then click "Save"
-5. If you intend to use InvenTree with this tool, click on "Settings > InvenTree" and fill in your InvenTree server address and credentials then click "Save" (optional: click on "Test" to get an API token)
+5. If you intend to use InvenTree with this tool, click on "Settings > InvenTree" and fill in your InvenTree server address and credentials then click "Save" (optional: click on "Test" to check communication with server) You can also use token authentication directly by leaving the username field empty and put your token into the password field.
 
 #### Get Digi-Key API token
 <details>

--- a/kintree/config/config_interface.py
+++ b/kintree/config/config_interface.py
@@ -98,10 +98,23 @@ def load_inventree_user_settings(user_config_path: str) -> dict:
     except TypeError:
         user_settings['PASSWORD'] = ''
 
+    proxies = user_settings.get('PROXIES', None)
+    if not proxies:
+        user_settings['PROXY_HTTP'] = ''
+        user_settings['PROXY_HTTPS'] = ''
+    else:
+        user_settings['PROXY_HTTP'] = proxies['http']
+        user_settings['PROXY_HTTPS'] = proxies['https']
+
     return user_settings
 
 
-def save_inventree_user_settings(enable: bool, server: str, username: str, password: str, user_config_path: str):
+def save_inventree_user_settings(enable: bool,
+                                 server: str,
+                                 username: str,
+                                 password: str,
+                                 proxies: dict,
+                                 user_config_path: str):
     ''' Save InvenTree user settings to file '''
     user_settings = {}
 
@@ -110,6 +123,7 @@ def save_inventree_user_settings(enable: bool, server: str, username: str, passw
     user_settings['USERNAME'] = username
     # Use base64 encoding to make password unreadable inside the file
     user_settings['PASSWORD'] = base64.b64encode(password.encode())
+    user_settings['PROXIES'] = proxies
 
     return dump_file(user_settings, user_config_path)
 

--- a/kintree/config/settings.py
+++ b/kintree/config/settings.py
@@ -308,6 +308,7 @@ def load_inventree_settings():
     global SERVER_ADDRESS
     global USERNAME
     global PASSWORD
+    global PROXIES
     global PART_URL_ROOT
 
     inventree_settings = config_interface.load_inventree_user_settings(INVENTREE_CONFIG)
@@ -315,6 +316,7 @@ def load_inventree_settings():
     SERVER_ADDRESS = inventree_settings.get('SERVER_ADDRESS', None)
     USERNAME = inventree_settings.get('USERNAME', None)
     PASSWORD = inventree_settings.get('PASSWORD', None)
+    PROXIES = inventree_settings.get('PROXIES', {})
     # Part URL
     if SERVER_ADDRESS:
         # If missing, append slash to root URL

--- a/kintree/database/inventree_api.py
+++ b/kintree/database/inventree_api.py
@@ -19,14 +19,24 @@ from inventree.company import Company, ManufacturerPart, SupplierPart
 from inventree.part import Part, PartCategory, Parameter, ParameterTemplate
 
 
-def connect(server: str, username: str, password: str, connect_timeout=5, silent=False) -> bool:
+def connect(server: str,
+            username: str,
+            password: str,
+            connect_timeout=5,
+            silent=False,
+            proxies={},
+            token='') -> bool:
     ''' Connect to InvenTree server and create API object '''
     from wrapt_timeout_decorator import timeout
     global inventree_api
 
     @timeout(dec_timeout=connect_timeout)
     def get_inventree_api_timeout():
-        return InvenTreeAPI(server, username=username, password=password)
+        return InvenTreeAPI(server,
+                            username=username,
+                            password=password,
+                            proxies=proxies,
+                            token=token)
 
     try:
         inventree_api = get_inventree_api_timeout()

--- a/kintree/database/inventree_interface.py
+++ b/kintree/database/inventree_interface.py
@@ -14,11 +14,17 @@ def connect_to_server(timeout=5) -> bool:
     ''' Connect to InvenTree server using user settings '''
     connect = False
     settings.load_inventree_settings()
+    if not settings.USERNAME:
+        token = settings.PASSWORD
+    else:
+        token = ''
 
     try:
         connect = inventree_api.connect(server=settings.SERVER_ADDRESS,
                                         username=settings.USERNAME,
                                         password=settings.PASSWORD,
+                                        proxies=settings.PROXIES,
+                                        token=token,
                                         connect_timeout=timeout)
     except TimeoutError:
         pass

--- a/kintree/gui/views/settings.py
+++ b/kintree/gui/views/settings.py
@@ -137,8 +137,18 @@ SETTINGS = {
             ft.TextField(),
             False,  # Browse disabled
         ],
-        'Password': [
+        'Password or Token': [
             'PASSWORD',
+            ft.TextField(),
+            False,  # Browse disabled
+        ],
+        'Http Proxy': [
+            'PROXY_HTTP',
+            ft.TextField(),
+            False,  # Browse disabled
+        ],
+        'Https Proxy': [
+            'PROXY_HTTPS',
             ft.TextField(),
             False,  # Browse disabled
         ],
@@ -738,7 +748,10 @@ class InvenTreeSettingsView(SettingsView):
                 enable=global_settings.ENABLE_INVENTREE,
                 server=SETTINGS[self.title]['Server Address'][1].value,
                 username=SETTINGS[self.title]['Username'][1].value,
-                password=SETTINGS[self.title]['Password'][1].value,
+                password=SETTINGS[self.title]['Password or Token'][1].value,
+                proxies={'http': SETTINGS[self.title]['Http Proxy'][1].value,
+                         'https': SETTINGS[self.title]['Https Proxy'][1].value
+                         },
                 user_config_path=self.settings_file[0]
             )
             # Alert user


### PR DESCRIPTION
implementation of #140 + additional support for tokens.

token connection check like done for the basic authentication is with the current state of the inventree-api not possible and will cause background-crashes if a not valid token is used. I will try to push a change to the api for their next version to catch this corner case. see https://github.com/inventree/inventree-python/issues/180