### PR TITLE
Add sanitization for the \x0a in the prices

### DIFF
--- a/kintree/database/inventree_api.py
+++ b/kintree/database/inventree_api.py
@@ -622,6 +622,13 @@ def create_supplier_part(part_id: int, manufacturer_name: str, manufacturer_mpn:
     return False, False
 
 
+def sanitize_price(price_in):
+    price = re.findall('\d+.\d+', price_in)[0]
+    price = price.replace(',', '.')
+    price = price.replace('\xa0', '')
+    return price
+
+
 def update_price_breaks(supplier_part, price_breaks: dict) -> bool:
     ''' Update the Price Breaks associated with a supplier part '''
     if not isinstance(supplier_part, SupplierPart):
@@ -643,8 +650,7 @@ def update_price_breaks(supplier_part, price_breaks: dict) -> bool:
         price = price_breaks[quantity]
         # remove everything but the numbers from the price break
         if isinstance(price, str):
-            price = re.findall('\d+.\d+', price)[0]
-            price = price.replace(',', '.')
+            price = sanitize_price(price)
         if quantity in price_breaks:
             old_price_break.save(data={'price': price})
             updated.append(quantity)
@@ -656,8 +662,7 @@ def update_price_breaks(supplier_part, price_breaks: dict) -> bool:
     for quantity, price in price_breaks.items():
         # remove everything but the numbers from the price break
         if isinstance(price, str):
-            price = re.findall('\d+.\d+', price)[0]
-            price = price.replace(',', '.')
+            price = sanitize_price(price)
         SupplierPriceBreak.create(inventree_api, {
             'part': supplier_part.pk,
             'quantity': quantity,


### PR DESCRIPTION
TME and Mouser adds spaces as a thousand separator in prices and with currencies (like our crap HUF) it is failing to create price break when product prices go over a thousand.