### PR TITLE
Use Mouser partunmber as name instead of description

### DIFF
--- a/kintree/search/mouser_api.py
+++ b/kintree/search/mouser_api.py
@@ -22,7 +22,7 @@ PARAMETERS_MAP = [
 
 def get_default_search_keys():
     return [
-        'Description',
+        'ManufacturerPartNumber',
         'Description',
         'revision',
         'keywords',


### PR DESCRIPTION
Using manufacturer part PN (exact device name) makes more sense to be used as a Part name in most cases than duplicating it's description. (I think).