### PR TITLE
fix LCSC API default URL

### DIFF
--- a/kintree/config/lcsc/lcsc_api.yaml
+++ b/kintree/config/lcsc/lcsc_api.yaml
@@ -1,1 +1,1 @@
-LCSC_API_URL: https://wmsc.lcsc.com/wmsc/product/detail?productCode=
+LCSC_API_URL: https://wmsc.lcsc.com/ftps/wm/product/detail?productCode=


### PR DESCRIPTION
LCSC seems to have changed the URL of their unofficial API