### PR TITLE
Fix Inventree tests and wait for official digikey-api release

### DIFF
--- a/run_tests.py
+++ b/run_tests.py
@@ -26,7 +26,7 @@ try:
 except IndexError:
     ENABLE_API = 0
 # Enable InvenTree tests
-ENABLE_INVENTREE = False
+ENABLE_INVENTREE = True
 # Enable KiCad tests
 ENABLE_KICAD = True
 # Set categories to test


### PR DESCRIPTION
- Inventree connection is always failing
- Ki-nTree `1.2.0` can't be uploaded to PyPI because of this error: https://github.com/sparkmicro/Ki-nTree/actions/runs/12538420052/job/34963596376
  - See reason here: https://github.com/pypi/warehouse/issues/7136