### PR TITLE
Fixed: Farnell API URL trailing space removed

### DIFF
--- a/kintree/search/element14_api.py
+++ b/kintree/search/element14_api.py
@@ -8,7 +8,7 @@ STORES = {
         'Bulgaria': 'bg.farnell.com ',
         'Czechia': 'cz.farnell.com',
         'Denmark': 'dk.farnell.com',
-        'Austria': 'at.farnell.com ',
+        'Austria': 'at.farnell.com',
         'Switzerland': 'ch.farnell.com',
         'Germany': 'de.farnell.com',
         'CPC UK': 'cpc.farnell.com',


### PR DESCRIPTION
The API URL for the Austrian Farnell store had a trailing space and was not working.

Fixed it by removing the trailing space character